### PR TITLE
fix: Fix perfect match scenario

### DIFF
--- a/src/fzy_lua.lua
+++ b/src/fzy_lua.lua
@@ -142,7 +142,7 @@ function fzy.score(needle, haystack, case_sensitive)
 
   if n == 0 or m == 0 or m > MATCH_MAX_LENGTH or n > m then
     return SCORE_MIN
-  elseif n == m then
+  elseif needle == haystack then
     return SCORE_MAX
   else
     local D = {}
@@ -173,7 +173,7 @@ function fzy.positions(needle, haystack, case_sensitive)
 
   if n == 0 or m == 0 or m > MATCH_MAX_LENGTH or n > m then
     return {}, SCORE_MIN
-  elseif n == m then
+  elseif needle == haystack then
     local consecutive = {}
     for i = 1, n do
       consecutive[i] = i

--- a/src/fzy_lua.lua
+++ b/src/fzy_lua.lua
@@ -77,11 +77,11 @@ local function precompute_bonus(haystack)
 end
 
 local function is_perfect_match(needle, haystack, case_sensitive)
-	if case_sensitive then
-		return needle == haystack
-	else
-		return string.lower(needle) == string.lower(haystack)
-	end
+  if case_sensitive then
+    return needle == haystack
+  else
+    return string.lower(needle) == string.lower(haystack)
+  end
 end
 
 local function compute(needle, haystack, D, M, case_sensitive)

--- a/src/fzy_lua.lua
+++ b/src/fzy_lua.lua
@@ -76,6 +76,14 @@ local function precompute_bonus(haystack)
   return match_bonus
 end
 
+local function is_perfect_match(needle, haystack, case_sensitive)
+	if case_sensitive then
+		return needle == haystack
+	else
+		return string.lower(needle) == string.lower(haystack)
+	end
+end
+
 local function compute(needle, haystack, D, M, case_sensitive)
   -- Note that the match bonuses must be computed before the arguments are
   -- converted to lowercase, since there are bonuses for camelCase.
@@ -142,7 +150,7 @@ function fzy.score(needle, haystack, case_sensitive)
 
   if n == 0 or m == 0 or m > MATCH_MAX_LENGTH or n > m then
     return SCORE_MIN
-  elseif needle == haystack then
+  elseif is_perfect_match(needle, haystack, case_sensitive) then
     return SCORE_MAX
   else
     local D = {}
@@ -173,7 +181,7 @@ function fzy.positions(needle, haystack, case_sensitive)
 
   if n == 0 or m == 0 or m > MATCH_MAX_LENGTH or n > m then
     return {}, SCORE_MIN
-  elseif needle == haystack then
+  elseif is_perfect_match(needle, haystack, case_sensitive) then
     local consecutive = {}
     for i = 1, n do
       consecutive[i] = i


### PR DESCRIPTION
In the Lua implementation the perfect match scenario had a bug where it would consider any string of the same length as a perfect match. This fixes it.
