### PR TITLE
ci: fix Windows tests + enable for PRs

### DIFF
--- a/.busted
+++ b/.busted
@@ -1,13 +1,6 @@
 return {
-    _all = {
-        coverage = false,
-        lpath = "src/?.lua;src/?/init.lua",
-    },
     default = {
         verbose = true,
         ROOT = {"test"},
-    },
-    tests = {
-        verbose = true,
     },
 }

--- a/.github/workflows/spec.yml
+++ b/.github/workflows/spec.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]
-        lua: ["5.1", "5.2", "5.3", "5.4", "luajit-2.1.0-beta3"]
+        lua: ["5.1", "5.2", "5.3", "5.4", "luajit"]
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/spec.yml
+++ b/.github/workflows/spec.yml
@@ -12,6 +12,9 @@ jobs:
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]
         lua: ["5.1", "5.2", "5.3", "5.4", "luajit"]
+      exclude:
+          - lua: juajit
+            os: windows-latest
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/spec.yml
+++ b/.github/workflows/spec.yml
@@ -27,7 +27,7 @@ jobs:
         python -m pip install hererocks
         python -m hererocks lua_install --${{ matrix.lua }} -rlatest
         . lua_install/bin/activate
-        luarocks install busted
+        luarocks install busted 2.1.2
 
     - name: Build
       run: |

--- a/.github/workflows/spec.yml
+++ b/.github/workflows/spec.yml
@@ -11,32 +11,31 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]
-        lua: ["lua 5.1", "lua 5.2", "lua 5.3", "lua 5.4", "luajit 2.1"]
+        lua: ["5.1", "5.2", "5.3", "5.4", "luajit-2.1.0-beta3"]
 
     steps:
     - uses: actions/checkout@v3
 
-    - name: Install Python
-      uses: actions/setup-python@v4
-      with:
-        python-version: '3.10'
+    - name: Install MSVC Compiler Toolchain
+      uses: ilammy/msvc-dev-cmd@v1
+      if: runner.os == 'Windows'
 
     - name: Install Lua
-      env:
-        # luajit fails to build on macos without this
-        MACOSX_DEPLOYMENT_TARGET: "10.15"
-      run: |
-        python -m pip install hererocks
-        python -m hererocks lua_install --${{ matrix.lua }} -rlatest
-        . lua_install/bin/activate
-        luarocks install busted
+      uses: leafo/gh-actions-lua@v10
+      with:
+        luaVersion: ${{ matrix.lua }}
+
+    - name: Install Luarocks
+      # NOTE: This is a fork with Windows support
+      uses: hishamhm/gh-actions-luarocks@master
 
     - name: Build
       run: |
-        . lua_install/bin/activate
         luarocks make
 
     - name: Test
       run: |
-        . lua_install/bin/activate
-        busted test/fzy_spec.lua
+        luarocks test
+      # FIXME: There seems to be a bug causing busted
+      # to fail on Windows, because it can't find LuaFileSystem
+      if: runner.os ~= 'Windows'

--- a/.github/workflows/spec.yml
+++ b/.github/workflows/spec.yml
@@ -1,6 +1,8 @@
 name: build
 
-on: [push]
+on: 
+  push:
+  pull_request:
 
 jobs:
   build:

--- a/.github/workflows/spec.yml
+++ b/.github/workflows/spec.yml
@@ -13,7 +13,7 @@ jobs:
         os: [macos-latest, ubuntu-latest, windows-latest]
         lua: ["5.1", "5.2", "5.3", "5.4", "luajit"]
       exclude:
-          - lua: juajit
+          - lua: luajit
             os: windows-latest
 
     steps:

--- a/.github/workflows/spec.yml
+++ b/.github/workflows/spec.yml
@@ -29,7 +29,8 @@ jobs:
         python -m pip install hererocks
         python -m hererocks lua_install --${{ matrix.lua }} -rlatest
         . lua_install/bin/activate
-        luarocks install busted 2.1.2
+        luarocks install LuaFileSystem
+        luarocks install busted
 
     - name: Build
       run: |

--- a/.github/workflows/spec.yml
+++ b/.github/workflows/spec.yml
@@ -12,7 +12,7 @@ jobs:
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]
         lua: ["5.1", "5.2", "5.3", "5.4", "luajit"]
-      exclude:
+        exclude:
           - lua: luajit
             os: windows-latest
 

--- a/.github/workflows/spec.yml
+++ b/.github/workflows/spec.yml
@@ -29,7 +29,6 @@ jobs:
         python -m pip install hererocks
         python -m hererocks lua_install --${{ matrix.lua }} -rlatest
         . lua_install/bin/activate
-        luarocks install LuaFileSystem
         luarocks install busted
 
     - name: Build
@@ -40,4 +39,4 @@ jobs:
     - name: Test
       run: |
         . lua_install/bin/activate
-        luarocks test
+        busted test/fzy_spec.lua

--- a/.github/workflows/spec.yml
+++ b/.github/workflows/spec.yml
@@ -38,4 +38,4 @@ jobs:
         luarocks test
       # FIXME: There seems to be a bug causing busted
       # to fail on Windows, because it can't find LuaFileSystem
-      if: runner.os ~= 'Windows'
+      if: runner.os != 'Windows'

--- a/src/match.c
+++ b/src/match.c
@@ -15,8 +15,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <strings.h>
-
 #include "bonus.h"
 
 


### PR DESCRIPTION
See https://github.com/swarn/fzy-lua/pull/8#issuecomment-1839161863.

It appears `busted` 2.2.0 doesn't work on Windows.